### PR TITLE
Adds occurred_at to Expense entity

### DIFF
--- a/lib/rexpense/entities/expense.rb
+++ b/lib/rexpense/entities/expense.rb
@@ -15,6 +15,7 @@ module Rexpense
       attribute :payer, Rexpense::Entities::Organization
       attribute :receiver, Rexpense::Entities::User
       attribute :liquidate_through_advancement, Boolean
+      attribute :occurred_at, DateTime
       attribute :created_at, DateTime
       attribute :updated_at, DateTime
     end

--- a/spec/lib/rexpense/entities/expense_spec.rb
+++ b/spec/lib/rexpense/entities/expense_spec.rb
@@ -9,6 +9,6 @@ describe Rexpense::Entities::Expense do
     :distance_kind, :destination, :origin, :amount, :approved_amount, :latitude,
     :longitude, :distance, :destination_latitude, :destination_longitude,
     :origin_longitude, :origin_latitude, :tags, :liquidate_through_advancement,
-    :created_at, :updated_at, :pre_expense_id, :payer, :receiver
+    :created_at, :updated_at, :pre_expense_id, :payer, :receiver, :occurred_at
   ]
 end


### PR DESCRIPTION
The Expense entity is missing the `occurred_at` attribute (which is available in the responses of Expense endpoints). This PR fixes this issue.